### PR TITLE
Updated fasterxml version number.

### DIFF
--- a/injectionApi/pom.xml
+++ b/injectionApi/pom.xml
@@ -41,13 +41,13 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.9.5</version>
+      <version>2.9.8</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.5</version>
+      <version>2.9.8</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
FasterXml updated blocks several classes from polymorphic deserialization.  (CVE-2018-19360, CVE-2018-19361, CVE-2018-19362)

Needs more compatability testing before releasing.
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9